### PR TITLE
Pass arguments to node in purs-nix run

### DIFF
--- a/purs-nix-command.nix
+++ b/purs-nix-command.nix
@@ -182,7 +182,7 @@ with builtins;
 
           run )
             ${compile'}
-            ${node-command (bundle.module or "Main")} \$\{@:2};;
+            ${node-command (bundle.module or "Main")} \$\{\@\:2\};;
 
           test )
             ${compile-test compile}

--- a/purs-nix-command.nix
+++ b/purs-nix-command.nix
@@ -182,7 +182,7 @@ with builtins;
 
           run )
             ${compile'}
-            ${node-command (bundle.module or "Main")};;
+            ${node-command (bundle.module or "Main")} \$\{@:2};;
 
           test )
             ${compile-test compile}

--- a/purs-nix-command.nix
+++ b/purs-nix-command.nix
@@ -182,7 +182,7 @@ with builtins;
 
           run )
             ${compile'}
-            ${node-command (bundle.module or "Main")} \$\{\@\:2\};;
+            ${node-command (bundle.module or "Main")} -- \$\{@:2} ;;
 
           test )
             ${compile-test compile}

--- a/purs-nix-command.nix
+++ b/purs-nix-command.nix
@@ -182,7 +182,7 @@ with builtins;
 
           run )
             ${compile'}
-            ${node-command (bundle.module or "Main")} -- \$\{@:2} ;;
+            ${node-command (bundle.module or "Main")} \$\{\@\:2\};;
 
           test )
             ${compile-test compile}


### PR DESCRIPTION
The goal of this pr is to pass any extra arguments given to `purs-nix run` to node so programs run by `purs-nix run` can take arguments. This does pass the arguments afaict, but is probably not the way to do it as it also throws 
```
/nix/store/975ccm7gjwm1b4az3g9xn9j15h7dsagh-purs-nix/bin/purs-nix: line 27: ${@:2}: command not found
```

Feel free to scrap this pr if this is a totally wrong approach or use it if I'm just making a syntax error.