### PR TITLE
document IIFE bundle format used by `spago bundle-app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@
 
   - To view the info of a package, use `nix run github:purs-nix/purs-nix#package-info.<package-name>`. (a namespaced package will need to have quotes around its name, as it contains a `.`. You can do that like this: `.#package-info.'"<namespace>.<name>"'`.)
 
+## Migrating from [`spago`](https://github.com/purescript/spago)
+
+There is a difference in the default [esbuild](https://esbuild.github.io/) [format](https://esbuild.github.io/api/#format) used by `purs-nix` and `spago`. The default used by `purs-nix` is [ESM format](https://esbuild.github.io/api/#format-esm). The default used by [`spago bundle-app`](https://github.com/purescript/spago#1-spago-bundle-app) is [IIFE format](https://esbuild.github.io/api/#format-iife). To match `spago`, specify [`bundle.esbuild.format = "iife"`](https://github.com/purs-nix/purs-nix/blob/master/docs/derivations.md#bundle), i.e.:
+```
+...
+bundle =
+  { ...
+    esbuild = { format = "iife"; };
+  }
+...
+```
+
 ## Contributing / Mirrors
 
 Bug reports and patches are always welcome. Feature requests and new features are also welcome, but please consider discussing them with the maintainer first.

--- a/docs/derivations.md
+++ b/docs/derivations.md
@@ -123,8 +123,6 @@ The upper options correspond to the flags you can pass `purs compile`.
 
 ```
 
-- `esbuild`: additional esbuild flags
-    - `format`: Specifies the [esbuild format](https://esbuild.github.io/api/#format). Default is [ESM format](https://esbuild.github.io/api/#format-esm). Note default for [`spago bundle-app`](https://github.com/purescript/spago#1-spago-bundle-app) is [IIFE format](https://esbuild.github.io/api/#format-iife); specify this with `"iife"`.
 - `main`: whether or not to automatically execute the main function of the module you're bundling.
 - `incremental`: whether or not to build the modules incrementally. This will almost certainly cause your build times to be slower, but may give some improvements when iterating on certain modules in very large projects.
 Note: turning this off will not disable the separate compiling of dependencies.

--- a/docs/derivations.md
+++ b/docs/derivations.md
@@ -123,6 +123,8 @@ The upper options correspond to the flags you can pass `purs compile`.
 
 ```
 
+- `esbuild`: additional esbuild flags
+    - `format`: Specifies the [esbuild format](https://esbuild.github.io/api/#format). Default is [ESM format](https://esbuild.github.io/api/#format-esm). Note default for [`spago bundle-app`](https://github.com/purescript/spago#1-spago-bundle-app) is [IIFE format](https://esbuild.github.io/api/#format-iife); specify this with `"iife"`.
 - `main`: whether or not to automatically execute the main function of the module you're bundling.
 - `incremental`: whether or not to build the modules incrementally. This will almost certainly cause your build times to be slower, but may give some improvements when iterating on certain modules in very large projects.
 Note: turning this off will not disable the separate compiling of dependencies.


### PR DESCRIPTION
With the `purs-nix` default bundle format ESM, the bundle produced by `purs-nix` did not immediately work as a replacement for the bundle produced by `spago bundle-app`. I realize now that `spago` uses a different bundle format by default: https://esbuild.github.io/api/#format-iife